### PR TITLE
fix: Adds tests for valid fetches and in/valid gets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,10 @@ module github.com/netlify/mailme
 go 1.13
 
 require (
+	github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32
 	github.com/netlify/netlify-commons v0.32.0
 	github.com/sirupsen/logrus v1.4.1
 	gopkg.in/alexcesaro/quotedprintable.v3 v3.0.0-20150716171945-2caba252f4dc // indirect
 	gopkg.in/gomail.v2 v2.0.0-20150902115704-41f357289737
+	gopkg.in/h2non/gock.v1 v1.1.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -24,6 +24,8 @@ github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRx
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542 h1:2VTzZjLZBgl62/EtslCrtky5vbi9dd7HrQPQIx6wqiw=
+github.com/h2non/parth v0.0.0-20190131123155-b4df798d6542/go.mod h1:Ow0tF8D4Kplbc8s8sSb3V2oUCygFHVp8gC3Dn6U4MNI=
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v0.9.1/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -60,6 +62,8 @@ github.com/nats-io/nkeys v0.0.2/go.mod h1:dab7URMsZm6Z/jp9Z5UGa87Uutgc2mVpXLC4B7
 github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OSON2c=
 github.com/nats-io/stan.go v0.4.5/go.mod h1:Ji7mK6gRZJSH1nc3ZJH6vi7zn/QnZhpR9Arm4iuzsUQ=
 github.com/nats-io/stan.go v0.5.0/go.mod h1:dYqB+vMN3C2F9pT1FRQpg9eHbjPj6mP0yYuyBNuXHZE=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32 h1:W6apQkHrMkS0Muv8G/TipAy/FJl/rCYT0+EuS8+Z0z4=
+github.com/nbio/st v0.0.0-20140626010706-e9e8d9816f32/go.mod h1:9wM+0iRr9ahx58uYLpLIr5fm8diHn0JbqRycJi6w0Ms=
 github.com/netlify/netlify-commons v0.32.0 h1:IgpqedBa6aFrc+daRgGZ+SmU9eBXlDXzKSAjevWmshM=
 github.com/netlify/netlify-commons v0.32.0/go.mod h1:xZH7auZrc/N/ZKS9BRO74yNf8i9LitXq1h6JVFZ2jTc=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
@@ -94,8 +98,9 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
-github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/tinylib/msgp v1.1.0/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tv42/httpunix v0.0.0-20150427012821-b75d8614f926/go.mod h1:9ESjWnEqriFuLhtthL60Sar/7RFoluCcXsuvEwTV5KM=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
@@ -128,6 +133,10 @@ gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/gomail.v2 v2.0.0-20150902115704-41f357289737 h1:NvePS/smRcFQ4bMtTddFtknbGCtoBkJxGmpSpVRafCc=
 gopkg.in/gomail.v2 v2.0.0-20150902115704-41f357289737/go.mod h1:LRQQ+SO6ZHR7tOkpBDuZnXENFzX8qRjMDMyPD6BRkCw=
+gopkg.in/h2non/gock.v1 v1.1.2 h1:jBbHXgGBK/AoPVfJh5x4r/WxIrElvbLel8TCZkkZJoY=
+gopkg.in/h2non/gock.v1 v1.1.2/go.mod h1:n7UGz/ckNChHiK05rDoiC4MYSunEC/lyaUm2WWaDva0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20190924164351-c8b7dadae555/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/mailme_test.go
+++ b/mailme_test.go
@@ -78,5 +78,5 @@ func TestInvalidVariable(t *testing.T) {
     data, err := cache.Get("http://www.example.com/templates/invalid")
 
     st.Reject(t, data, invalidTemplateBody)
-    st.Reject(t, err, nil)
+    st.Expect(t, err, nil)
 }

--- a/mailme_test.go
+++ b/mailme_test.go
@@ -1,0 +1,82 @@
+package mailme
+
+import (
+	"testing"
+
+	"gopkg.in/h2non/gock.v1"
+
+	"github.com/nbio/st"
+	"github.com/sirupsen/logrus"
+)
+
+func TestFetchTemplate(t *testing.T) {
+    defer gock.Off()
+
+    var templateBody = "something like QWERTYUIOP."
+
+    gock.New("http://www.example.com").
+    Get("/templates/fetch").
+    Reply(200).
+    BodyString(templateBody)
+
+    var logger = logrus.New()
+
+    var cache = &TemplateCache{
+        templates: map[string]*MailTemplate{},
+        funcMap: map[string]interface{}{},
+        logger: logger,
+    }
+
+    data, err := cache.fetchTemplate("http://www.example.com/templates/fetch", 3)
+
+    st.Expect(t, data, templateBody)
+    st.Expect(t, err, nil)
+}
+
+func TestValidVariables(t *testing.T) {
+    var validTemplateBody = "This variable has the correct {{ .myTemplateVariable }} number of braces."
+
+    defer gock.Off()
+
+    gock.New("http://www.example.com").
+    Get("/templates/valid").
+    Reply(200).
+    BodyString(validTemplateBody)
+    
+    var logger = logrus.New()
+    
+    var cache = &TemplateCache{
+        templates: map[string]*MailTemplate{},
+        funcMap: map[string]interface{}{},
+        logger: logger,
+    }
+
+    data, err := cache.Get("http://www.example.com/templates/valid")
+
+    st.Reject(t, data, nil)
+    st.Expect(t, err, nil)
+}
+
+func TestInvalidVariable(t *testing.T) {
+    var invalidTemplateBody = "This variable has the wrong {{{ .myTemplateVariable }}} number of braces."
+
+    defer gock.Off()
+
+    gock.New("http://www.example.com").
+    Get("/templates/invalid").
+    Reply(200).
+    BodyString(invalidTemplateBody)
+    
+    var logger = logrus.New()
+    
+    var cache = &TemplateCache{
+        templates: map[string]*MailTemplate{},
+        funcMap: map[string]interface{}{},
+        logger: logger,
+    }
+
+    data, err := cache.Get("http://www.example.com/templates/invalid")
+
+    st.Reject(t, data, invalidTemplateBody)
+    st.Reject(t, err, nil)
+}


### PR DESCRIPTION
As part of [this issue](https://github.com/supabase/gotrue/issues/278) in Supabase's fork of GoTrue which uses mailme, custom templates failed to get fetches and retrieved from the cache due to invalid template variable use.

See: https://github.com/supabase/gotrue/issues/278

The issue was the the template used a variable with three braces:

```
This variable has the wrong {{{ .myTemplateVariable }}} number of braces.
```

And when the mailme "gets" the template, an error:

> unexpected "{" in command

is raised.

This caused Supabase to ignore the custom template and use the default content to send mails.

This PR adds tests to:

* simply fetch a template via a mocked HTTP server
* gets a valid template
* tries to get an invalid template and expects an error

Please note: this my first Go PR ever and also my first Go testing framework PR, so please forgive me if the tests are not as expected or even if some packages were updated incorrectly.

